### PR TITLE
Some refactor to include view models for the views (partial) + adaptation of Kailan's code

### DIFF
--- a/Travel.xcodeproj/project.pbxproj
+++ b/Travel.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -73,6 +73,10 @@
 		98DF07442CD807CB00694B97 /* SelectFriendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFriendsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		98DF079F2CD9A59200694B97 /* ViewModels */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ViewModels; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		37BC41B82CD1911B007AA26B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -105,6 +109,7 @@
 		37BC41BD2CD1911B007AA26B /* Travel */ = {
 			isa = PBXGroup;
 			children = (
+				98DF079F2CD9A59200694B97 /* ViewModels */,
 				37BC41DA2CD19455007AA26B /* Views */,
 				37BC41D72CD192BB007AA26B /* DataRepository */,
 				37BC41D32CD19199007AA26B /* Models */,
@@ -184,6 +189,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				98DF079F2CD9A59200694B97 /* ViewModels */,
 			);
 			name = Travel;
 			packageProductDependencies = (

--- a/Travel.xcodeproj/project.pbxproj
+++ b/Travel.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		98DF071F2CD7165500694B97 /* EditMeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DF071E2CD7165500694B97 /* EditMeView.swift */; };
 		98DF07212CD7FAD000694B97 /* CompanionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DF07202CD7FAD000694B97 /* CompanionRowView.swift */; };
 		98DF07452CD807CB00694B97 /* SelectFriendsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DF07442CD807CB00694B97 /* SelectFriendsView.swift */; };
+		98DF07CB2CDA940F00694B97 /* DayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DF07CA2CDA940F00694B97 /* DayView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -71,6 +72,7 @@
 		98DF071E2CD7165500694B97 /* EditMeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeView.swift; sourceTree = "<group>"; };
 		98DF07202CD7FAD000694B97 /* CompanionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionRowView.swift; sourceTree = "<group>"; };
 		98DF07442CD807CB00694B97 /* SelectFriendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFriendsView.swift; sourceTree = "<group>"; };
+		98DF07CA2CDA940F00694B97 /* DayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -162,6 +164,7 @@
 				37BC41DE2CD194E5007AA26B /* TripCardView.swift */,
 				37BC41E02CD19501007AA26B /* MyTripsView.swift */,
 				37BC41E22CD1A11F007AA26B /* NewTripView.swift */,
+				98DF07CA2CDA940F00694B97 /* DayView.swift */,
 				98DF07162CD6CAC000694B97 /* MeView.swift */,
 				98DF071E2CD7165500694B97 /* EditMeView.swift */,
 				98DF07182CD6DA1700694B97 /* MyPostsView.swift */,
@@ -274,6 +277,7 @@
 				98DF071F2CD7165500694B97 /* EditMeView.swift in Sources */,
 				98DF07212CD7FAD000694B97 /* CompanionRowView.swift in Sources */,
 				98DF070B2CD5EB5600694B97 /* Post.swift in Sources */,
+				98DF07CB2CDA940F00694B97 /* DayView.swift in Sources */,
 				37BC41E72CD1BA5D007AA26B /* TripDetailsView.swift in Sources */,
 				98DF07112CD5EBB800694B97 /* LocationRepository.swift in Sources */,
 				37BC41D92CD192CE007AA26B /* TripRepository.swift in Sources */,

--- a/Travel/DataRepository/TripRepository.swift
+++ b/Travel/DataRepository/TripRepository.swift
@@ -40,7 +40,8 @@ class TripRepository: ObservableObject {
   func addTrip(_ trip: Trip) {
     // Function to add a new trip to Firestore
     do {
-      try store.collection(path).document(trip.id).setData(from: trip)
+			let newTrip = trip
+      _ = try store.collection(path).addDocument(from: newTrip)
     } catch {
       print("Error adding trip: \(error.localizedDescription)")
     }

--- a/Travel/DataRepository/TripRepository.swift
+++ b/Travel/DataRepository/TripRepository.swift
@@ -41,7 +41,7 @@ class TripRepository: ObservableObject {
     // Function to add a new trip to Firestore
     do {
 			let newTrip = trip
-      _ = try store.collection(path).addDocument(from: newTrip)
+      _ = try store.collection(path).document(newTrip.id).setData(from: newTrip)
     } catch {
       print("Error adding trip: \(error.localizedDescription)")
     }

--- a/Travel/DataRepository/TripRepository.swift
+++ b/Travel/DataRepository/TripRepository.swift
@@ -46,5 +46,27 @@ class TripRepository: ObservableObject {
       print("Error adding trip: \(error.localizedDescription)")
     }
   }
+	
+	func updateTravelers(trip: Trip, travelers: [SimpleUser]) {
+		guard !trip.id.isEmpty else { return }  // Check that the trip id is valid
+
+		let travelerData = travelers.map { traveler in
+			[
+				"userId": traveler.id,
+				"name": traveler.name,
+				"photo": traveler.photo
+			]
+		}
+		
+		store.collection(path).document(trip.id).updateData([
+			"travelers": travelerData  // Storing travelers as a list of dictionaries
+		]) { error in
+			if let error = error {
+				print("Error updating travelers: \(error)")
+			} else {
+				print("Travelers list successfully updated.")
+			}
+		}
+	}
 }
 

--- a/Travel/Models/Trip.swift
+++ b/Travel/Models/Trip.swift
@@ -41,10 +41,14 @@ struct Trip: Identifiable, Codable, Comparable {
 		id: "1",
 		tripName: "Miami",
 		startDate: "2024-03-05",
-		endDate: "2024-03-08",
+		endDate: "2024-03-07",
 		photo: "",
 		color: "blue",
-		days: [Day](),
+		days: [
+			Day(id: UUID(), date: "2024-03-05", events: [Event]()),
+			Day(id: UUID(), date: "2024-03-06", events: [Event]()),
+			Day(id: UUID(), date: "2024-03-07", events: [Event]())
+		],
 		travelers: [SimpleUser.clara]
 	)
 	

--- a/Travel/Models/Trip.swift
+++ b/Travel/Models/Trip.swift
@@ -45,7 +45,7 @@ struct Trip: Identifiable, Codable, Comparable {
 		photo: "",
 		color: "blue",
 		days: [Day](),
-		travelers: [SimpleUser.bob]
+		travelers: [SimpleUser.clara]
 	)
 	
 }

--- a/Travel/ViewModels/CompanionViewModel.swift
+++ b/Travel/ViewModels/CompanionViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  CompanionViewModel.swift
+//  Travel
+//
+//  Created by Emma Shi on 11/5/24.
+//
+
+import Foundation
+import Combine
+
+class CompanionViewModel: ObservableObject {
+	@Published var travelers: [SimpleUser] = []
+	private var tripViewModel: TripViewModel
+	private var cancellables: Set<AnyCancellable> = []
+	private let tripRepository = TripRepository()
+
+	init(tripViewModel: TripViewModel) {
+		self.tripViewModel = tripViewModel
+		self.travelers = tripViewModel.trip.travelers // Initialize travelers from the trip
+	}
+
+	func removeTraveler(_ traveler: SimpleUser) {
+		// Remove the traveler from Firestore directly using the repository
+		if let index = travelers.firstIndex(where: { $0.id == traveler.id }) {
+			travelers.remove(at: index) // Update local list
+			// Call the repository method to update Firestore
+			tripRepository.updateTravelers(trip: tripViewModel.trip, travelers: travelers)
+		}
+	}
+}

--- a/Travel/ViewModels/TripListViewModel.swift
+++ b/Travel/ViewModels/TripListViewModel.swift
@@ -1,0 +1,29 @@
+//
+//  TripListViewModel.swift
+//  Travel
+//
+//  Created by Emma Shi on 11/4/24.
+//
+
+import Foundation
+import Combine
+
+class TripListViewModel: ObservableObject {
+	@Published var tripViewModels: [TripViewModel] = []
+	private var cancellables: Set<AnyCancellable> = []
+	
+	@Published var tripRepository = TripRepository()
+	@Published var trips: [Trip] = []
+	
+	init() {
+		tripRepository.$trips.map { trips in
+			trips.map(TripViewModel.init)
+		}
+		.assign(to: \.tripViewModels, on: self)
+		.store(in: &cancellables)
+	}
+	
+	func add(_ trip: Trip) {
+		tripRepository.addTrip(trip)
+	}
+}

--- a/Travel/ViewModels/TripViewModel.swift
+++ b/Travel/ViewModels/TripViewModel.swift
@@ -10,7 +10,6 @@ import Combine
 
 class TripViewModel: ObservableObject, Identifiable {
 	private let tripRepository = TripRepository()
-	
 	@Published var trip: Trip
 	private var cancellables: Set<AnyCancellable> = []
 	var id = ""

--- a/Travel/ViewModels/TripViewModel.swift
+++ b/Travel/ViewModels/TripViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  TripViewModel.swift
+//  Travel
+//
+//  Created by Emma Shi on 11/4/24.
+//
+
+import Foundation
+import Combine
+
+class TripViewModel: ObservableObject, Identifiable {
+	private let tripRepository = TripRepository()
+	
+	@Published var trip: Trip
+	private var cancellables: Set<AnyCancellable> = []
+	var id = ""
+	
+	@Published var days: [Day] = []
+	
+	init(trip: Trip) {
+		self.trip = trip
+		$trip
+			.compactMap { $0.id }
+			.assign(to: \.id, on: self)
+			.store(in: &cancellables)
+	}
+	
+}

--- a/Travel/ViewModels/TripViewModel.swift
+++ b/Travel/ViewModels/TripViewModel.swift
@@ -14,8 +14,6 @@ class TripViewModel: ObservableObject, Identifiable {
 	private var cancellables: Set<AnyCancellable> = []
 	var id = ""
 	
-	@Published var days: [Day] = []
-	
 	init(trip: Trip) {
 		self.trip = trip
 		$trip
@@ -23,5 +21,4 @@ class TripViewModel: ObservableObject, Identifiable {
 			.assign(to: \.id, on: self)
 			.store(in: &cancellables)
 	}
-	
 }

--- a/Travel/Views/CompanionRowView.swift
+++ b/Travel/Views/CompanionRowView.swift
@@ -29,6 +29,8 @@ struct CompanionRowView: View {
 		}
 		.padding(.horizontal, 30)
 	}
+	
+	
 }
 
 #Preview {

--- a/Travel/Views/CompanionsView.swift
+++ b/Travel/Views/CompanionsView.swift
@@ -8,16 +8,57 @@
 import SwiftUI
 
 struct CompanionsView: View {
-	var people: [SimpleUser]
+	@ObservedObject var companionViewModel: CompanionViewModel
+	@Environment(\.presentationMode) var presentationMode
+	@State private var showAlert = false
+	@State private var travelerToRemove: SimpleUser? // Traveler to remove
+	
+	init(tripViewModel: TripViewModel) {
+		self.companionViewModel = CompanionViewModel(tripViewModel: tripViewModel)
+	}
 	
 	var body: some View {
 		VStack {
 			VStack {
-				ForEach(people) { person in
-					CompanionRowView(person: person)
+				ForEach(companionViewModel.travelers) { person in
+					if person.id != User.example.id {
+						HStack(spacing: 20) {
+							Circle()
+								.fill(.blue)
+								.frame(width: 50, height: 50)
+							Text(person.name)
+								.font(.title3)
+								.fontWeight(.semibold)
+							Spacer()
+							Button(action: {
+								travelerToRemove = person
+								showAlert = true
+							}) {
+								Text("Remove")
+									.padding(12)
+									.background(Color("LightPurple"))
+									.foregroundColor(Color.black)
+									.clipShape(RoundedRectangle(cornerRadius: 10))
+							}
+						}
+						.padding(.horizontal, 30)
+					}
 				}
 			}
 			.padding(.vertical)
+			.alert(isPresented: $showAlert) {
+				Alert(
+					title: Text("Remove Companion"),
+					message: Text("Are you sure you want to remove \(travelerToRemove?.name ?? "") from this trip?"),
+					primaryButton: .destructive(Text("Remove")) {
+						if let traveler = travelerToRemove {
+							companionViewModel.removeTraveler(traveler)
+							presentationMode.wrappedValue.dismiss()
+						}
+					},
+					secondaryButton: .cancel())
+			}
+			
 			NavigationLink(destination: SelectFriendsView()) {
 				ZStack {
 					Rectangle()
@@ -43,5 +84,5 @@ struct CompanionsView: View {
 }
 
 #Preview {
-	CompanionsView(people: [SimpleUser.bob, SimpleUser.clara])
+	CompanionsView(tripViewModel: TripViewModel(trip: Trip.example))
 }

--- a/Travel/Views/DayView.swift
+++ b/Travel/Views/DayView.swift
@@ -1,0 +1,61 @@
+//
+//  DayView.swift
+//  Travel
+//
+//  Created by k mao on 11/4/24.
+//
+
+import SwiftUI
+
+struct DayView: View {
+	let day: Day // Replace `String` with your `Day` model type if it's more complex
+	@Binding var searchText: String
+
+	var body: some View {
+		ScrollView {
+			// Itinerary section
+			Text("Itinerary")
+				.font(.title2)
+				.fontWeight(.semibold)
+				.padding(.leading, 20)
+				.frame(maxWidth: .infinity, alignment: .leading)
+			
+			Rectangle()
+				.fill(Color(.systemGray6))
+				.frame(height: 200)
+				.cornerRadius(10)
+				.padding(.horizontal, 20)
+				.padding(.bottom, 10)
+			
+			// Add to Itinerary section
+			Text("Add to Itinerary")
+				.font(.title2)
+				.fontWeight(.semibold)
+				.padding(.leading, 20)
+				.frame(maxWidth: .infinity, alignment: .leading)
+			
+			TextField("Search for a place", text: $searchText)
+				.padding()
+				.background(Color(.systemGray5))
+				.cornerRadius(10)
+				.padding(.horizontal, 20)
+				.padding(.bottom, 10)
+			
+			// Map section
+			Text("Map")
+				.font(.title2)
+				.fontWeight(.semibold)
+				.padding(.leading, 20)
+				.frame(maxWidth: .infinity, alignment: .leading)
+			
+			Rectangle()
+				.fill(Color(.systemGray6))
+				.frame(height: 200)
+				.cornerRadius(10)
+				.padding(.horizontal, 20)
+			
+			Spacer()
+			
+		}
+	}
+}

--- a/Travel/Views/MyTripsView.swift
+++ b/Travel/Views/MyTripsView.swift
@@ -8,10 +8,13 @@
 import SwiftUI
 
 struct MyTripsView: View {
-  @ObservedObject var tripRepository = TripRepository()
+	@ObservedObject var tripListViewModel = TripListViewModel()
+//  @ObservedObject var tripRepository = TripRepository()
   @State private var showNewTripView = false
 
   var body: some View {
+		let tripViewModels = tripListViewModel.tripViewModels.sorted(by: {$0.trip > $1.trip})
+		
     NavigationView {
       VStack {
         HStack {
@@ -32,9 +35,9 @@ struct MyTripsView: View {
         }
         
         ScrollView {
-          ForEach(tripRepository.trips) { trip in
-            NavigationLink(destination: TripDetailsView(trip: trip)) {
-              TripCardView(trip: trip)
+					ForEach(tripViewModels) { tVM in
+						NavigationLink(destination: TripDetailsView(trip: tVM.trip)) {
+							TripCardView(trip: tVM.trip)
                 .padding(.bottom, 10)
                 .padding(.top, 10)
             }
@@ -47,9 +50,6 @@ struct MyTripsView: View {
         NewTripView()
           .presentationDetents([.fraction(0.97)])
           .presentationDragIndicator(.visible)
-      }
-      .onAppear {
-        tripRepository.get()
       }
     }
   }

--- a/Travel/Views/MyTripsView.swift
+++ b/Travel/Views/MyTripsView.swift
@@ -36,7 +36,7 @@ struct MyTripsView: View {
         
         ScrollView {
 					ForEach(tripViewModels) { tVM in
-						NavigationLink(destination: TripDetailsView(trip: tVM.trip)) {
+						NavigationLink(destination: TripDetailsView(tVM: tVM)) {
 							TripCardView(trip: tVM.trip)
                 .padding(.bottom, 10)
                 .padding(.top, 10)

--- a/Travel/Views/MyTripsView.swift
+++ b/Travel/Views/MyTripsView.swift
@@ -44,7 +44,7 @@ struct MyTripsView: View {
       }
       .navigationBarHidden(true)
       .sheet(isPresented: $showNewTripView) {
-        NewTripView(tripRepository: tripRepository)
+        NewTripView()
           .presentationDetents([.fraction(0.97)])
           .presentationDragIndicator(.visible)
       }

--- a/Travel/Views/NewTripView.swift
+++ b/Travel/Views/NewTripView.swift
@@ -65,9 +65,9 @@ struct NewTripView: View {
             endDate: formatDate(date: endDate),
             photo: "", // Placeholder
             color: "blue", // Placeholder color
-						days: generateDays(from: startDate, to: endDate),
+						days: generateDays(startDate: startDate, endDate: endDate),
 						// for travelers can initially include the mock user that we would declare as the user of the current session
-						travelers: [SimpleUser]()
+						travelers: [SimpleUser.alice]
           )
           
           // Save the new trip to the repository
@@ -92,22 +92,33 @@ struct NewTripView: View {
 		return formatter.string(from: date)
   }
 	
-	private func generateDays(from start: Date, to end: Date) -> [Day] {
+	private func generateDays(startDate: Date, endDate: Date) -> [Day] {
 		var days: [Day] = []
-		let normStart = Calendar.current.startOfDay(for: start)
-		let normEnd = Calendar.current.startOfDay(for: end)
-		let oneDay: TimeInterval = 24 * 60 * 60
-		var current = normStart
+		var currentDate = startDate
+		let calendar = Calendar.current
 		
-		while current <= normEnd {
-			days.append(Day(id: UUID(), date: formatDate(date: current), events: [Event]()))
-				// Move to the next day
-			current = current.addingTimeInterval(oneDay)
+		if calendar.isDate(startDate, inSameDayAs: endDate) {
+			let dateString = formatDate(date: currentDate)
+			let id = UUID()
+			let day = Day(id: id, date: dateString, events: [])
+			days.append(day)
+			print("here\n")
+			return days
+		}
+		
+		while currentDate <= endDate.addingTimeInterval(86400) {
+			let dateString = formatDate(date: currentDate)
+			let id = UUID()
+			let day = Day(id: id, date: dateString, events: [])
+			days.append(day)
+			
+			currentDate = currentDate.addingTimeInterval(86400)
 		}
 		
 		return days
 	}
 }
+
 
 struct NewTripView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Travel/Views/NewTripView.swift
+++ b/Travel/Views/NewTripView.swift
@@ -8,10 +8,12 @@
 import SwiftUI
 
 struct NewTripView: View {
+	@ObservedObject var tripListViewModel = TripListViewModel()
+	
   @State private var tripName: String = ""
   @State private var showDatePicker = false
   @Environment(\.presentationMode) var presentationMode
-  @ObservedObject var tripRepository: TripRepository
+//  @ObservedObject var tripRepository: TripRepository
 
   var body: some View {
     NavigationView {
@@ -69,8 +71,8 @@ struct NewTripView: View {
           )
           
           // Save the new trip to the repository
-          tripRepository.trips.append(newTrip)
-          tripRepository.addTrip(newTrip)
+//          tripRepository.trips.append(newTrip)
+					tripListViewModel.add(newTrip)
           
           // Dismiss both the date picker and the new trip view
           showDatePicker = false
@@ -109,6 +111,6 @@ struct NewTripView: View {
 
 struct NewTripView_Previews: PreviewProvider {
   static var previews: some View {
-    NewTripView(tripRepository: TripRepository())
+    NewTripView()
   }
 }

--- a/Travel/Views/TripDetailsView.swift
+++ b/Travel/Views/TripDetailsView.swift
@@ -10,14 +10,13 @@ import SwiftUI
 struct TripDetailsView: View {
   var trip: Trip
   @State private var days: [String] = []
-  @State private var selectedIndex = 0
   @State private var searchText: String = ""
+	@State private var currentIndex = 0
+	@State private var selectedIndex = 0
 
 	var body: some View {
-			// 1. name + companion row
-			// 2. date change row + main content (scroll)
 		VStack {
-			// Name and companions row
+			// MARK: Name and companions row
 			HStack() {
 				Text(trip.tripName)
 					.font(.largeTitle)
@@ -35,21 +34,22 @@ struct TripDetailsView: View {
 					}
 				.frame(maxWidth: .infinity, alignment: .trailing)
 			)
-			// Switch date row
-			if !days.isEmpty {
+			
+			// MARK: Day View
+			if !trip.days.isEmpty {
 				HStack {
 					Button(action: {
-						if selectedIndex > 0 {
-							selectedIndex -= 1
+						if currentIndex > 0 {
+							currentIndex -= 1
 						}
 					}) {
 						Image(systemName: "arrow.backward")
 					}
-					.disabled(selectedIndex == 0)
+					.disabled(currentIndex == 0)
 					
 					Spacer()
 					
-					Text("Day \(selectedIndex + 1): \(days[selectedIndex])")
+					Text("Day \(currentIndex + 1): \(trip.days[currentIndex].date)")
 						.font(.headline)
 						.padding()
 						.background(Color(.systemGray5))
@@ -58,62 +58,21 @@ struct TripDetailsView: View {
 					Spacer()
 					
 					Button(action: {
-						if selectedIndex < days.count - 1 {
-							selectedIndex += 1
+						if currentIndex < trip.days.count - 1 {
+							currentIndex += 1
 						}
 					}) {
 						Image(systemName: "arrow.forward")
 					}
-					.disabled(selectedIndex == days.count - 1)
+					.disabled(currentIndex == trip.days.count - 1)
 				}
 				.padding(.horizontal)
 				.padding(.bottom, 10)
 				
-				// Main content needs to scroll
-				ScrollView {
-					// Itinerary section
-					Text("Itinerary")
-						.font(.title2)
-						.fontWeight(.semibold)
-						.padding(.leading, 20)
-						.frame(maxWidth: .infinity, alignment: .leading)
-					
-					Rectangle()
-						.fill(Color(.systemGray6))
-						.frame(height: 200)
-						.cornerRadius(10)
-						.padding(.horizontal, 20)
-						.padding(.bottom, 10)
-					
-					// Add to Itinerary section
-					Text("Add to Itinerary")
-						.font(.title2)
-						.fontWeight(.semibold)
-						.padding(.leading, 20)
-						.frame(maxWidth: .infinity, alignment: .leading)
-					
-					TextField("Search for a place", text: $searchText)
-						.padding()
-						.background(Color(.systemGray5))
-						.cornerRadius(10)
-						.padding(.horizontal, 20)
-						.padding(.bottom, 10)
-					
-					// Map section
-					Text("Map")
-						.font(.title2)
-						.fontWeight(.semibold)
-						.padding(.leading, 20)
-						.frame(maxWidth: .infinity, alignment: .leading)
-					
-					Rectangle()
-						.fill(Color(.systemGray6))
-						.frame(height: 200)
-						.cornerRadius(10)
-						.padding(.horizontal, 20)
-					
-					Spacer()
-				}
+				// One day view for each day object
+				DayView(day: trip.days[currentIndex], searchText: $searchText)
+					.frame(maxWidth: .infinity, maxHeight: .infinity)
+					.transition(.slide)
 			} else {
 				Text("Loading days...")
 					.font(.subheadline)
@@ -121,39 +80,9 @@ struct TripDetailsView: View {
 					.padding()
 			}
 		}
-		.onAppear {
-			loadDays()
-		}
 		// this will make the tab bar hidden forever even when return to my trips page
 //		.toolbar(.hidden, for: .tabBar)
 	}
-	
-
-  private func loadDays() {
-    days = generateDateList(from: trip.startDate, to: trip.endDate)
-  }
-
-  private func generateDateList(from startDate: String, to endDate: String) -> [String] {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd"
-    guard let start = dateFormatter.date(from: startDate),
-          let end = dateFormatter.date(from: endDate) else {
-      return []
-    }
-    
-    var dates: [String] = []
-    var currentDate = start
-    
-    while currentDate <= end {
-      dates.append(dateFormatter.string(from: currentDate))
-      guard let nextDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate) else {
-        break
-      }
-      currentDate = nextDate
-    }
-    
-    return dates
-  }
 }
 
 struct TripDetailsView_Previews: PreviewProvider {

--- a/Travel/Views/TripDetailsView.swift
+++ b/Travel/Views/TripDetailsView.swift
@@ -8,24 +8,23 @@
 import SwiftUI
 
 struct TripDetailsView: View {
-  var trip: Trip
-  @State private var days: [String] = []
+	@ObservedObject var tVM: TripViewModel
   @State private var searchText: String = ""
 	@State private var currentIndex = 0
-	@State private var selectedIndex = 0
 
 	var body: some View {
 		VStack {
 			// MARK: Name and companions row
 			HStack() {
-				Text(trip.tripName)
+				Text(tVM.trip.tripName)
 					.font(.largeTitle)
 					.fontWeight(.bold)
 					.frame(maxWidth: .infinity, alignment: .center)
 			}
 			// Use overlay for the companion link to ensure the trip name is at the center
 			.overlay(
-				NavigationLink(destination: CompanionsView(people: trip.travelers))
+				NavigationLink(
+					destination: CompanionsView(tripViewModel: tVM))
 				{
 					Image(systemName: "person.3")
 						.font(.title)
@@ -36,7 +35,7 @@ struct TripDetailsView: View {
 			)
 			
 			// MARK: Day View
-			if !trip.days.isEmpty {
+			if !tVM.trip.days.isEmpty {
 				HStack {
 					Button(action: {
 						if currentIndex > 0 {
@@ -49,7 +48,7 @@ struct TripDetailsView: View {
 					
 					Spacer()
 					
-					Text("Day \(currentIndex + 1): \(trip.days[currentIndex].date)")
+					Text("Day \(currentIndex + 1): \(tVM.trip.days[currentIndex].date)")
 						.font(.headline)
 						.padding()
 						.background(Color(.systemGray5))
@@ -58,19 +57,19 @@ struct TripDetailsView: View {
 					Spacer()
 					
 					Button(action: {
-						if currentIndex < trip.days.count - 1 {
+						if currentIndex < tVM.trip.days.count - 1 {
 							currentIndex += 1
 						}
 					}) {
 						Image(systemName: "arrow.forward")
 					}
-					.disabled(currentIndex == trip.days.count - 1)
+					.disabled(currentIndex == tVM.trip.days.count - 1)
 				}
 				.padding(.horizontal)
 				.padding(.bottom, 10)
 				
 				// One day view for each day object
-				DayView(day: trip.days[currentIndex], searchText: $searchText)
+				DayView(day: tVM.trip.days[currentIndex], searchText: $searchText)
 					.frame(maxWidth: .infinity, maxHeight: .infinity)
 					.transition(.slide)
 			} else {
@@ -87,6 +86,6 @@ struct TripDetailsView: View {
 
 struct TripDetailsView_Previews: PreviewProvider {
   static var previews: some View {
-		TripDetailsView(trip: Trip.example)
+		TripDetailsView(tVM: TripViewModel(trip: Trip.example))
   }
 }


### PR DESCRIPTION
This PR is mainly for starting to include viewmodels in the application to handle CRUD operations in views. For now these two commits add a trip list view model and trip view model to handle the create new trip process at the trip list view. 

Commit 5d5a5ed contains changes to my codebase based on Kailan's commits from #2 , specifically changed how day objects are generated when creating a new trip and the layout + logic of the trip detail view

Update in 3c4daa7: 
- Added the feature to remove a companion from a trip (for now only removes a simple user from a trip, not yet removing the trip id from a user's trips).  
- Remaining issue: when updating the travelers, since it is contained in a trip, the view would revert back to the trip details view after removing a companion. For now the app transitions back to the trip detail view. Need discussion over this action whether it is changeable in version 2.